### PR TITLE
fix: axios 수정 (/api 삽입) **라우팅 관련 정리**

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,22 +1,14 @@
 import axios from "axios";
 
 const client = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:8000",
+  // 👇 [수정] baseURL을 '/api'로 변경하여 Vite 프록시를 통하도록 합니다.
+  baseURL: "/api",
+
+  // 👇 쿠키 기반 인증을 위해 이 옵션은 반드시 필요합니다.
   withCredentials: true,
 });
 
-// Attach Authorization header when token is present
-client.interceptors.request.use((config) => {
-  try {
-    const token = localStorage.getItem("token");
-    if (token) {
-      config.headers = config.headers || {};
-      config.headers["Authorization"] = `Bearer ${token}`;
-    }
-  } catch (_) {
-    // ignore
-  }
-  return config;
-});
+// 👇 [삭제] localStorage에서 토큰을 읽어 헤더에 추가하던 인터셉터는
+// 쿠키 방식에서는 더 이상 필요 없으므로 완전히 삭제합니다.
 
 export default client;


### PR DESCRIPTION
# API 통신 가이드

## 1. 프론트엔드 페이지 이동 (SPA Navigation)
**목적**: 새로고침 없이 화면 전환
**설정**: App.jsx의 <Route> 정의
**사용**: `<Link to="/dashboard">`
**금지**: 페이지 이동에 axios 사용 ❌

## 2. 백엔드 데이터 요청 (API Call)
**목적**: 서버와 데이터 통신
**필수**: `import client from "../api/client"`
**자동 처리**: 
  - `/api` prefix 추가
  - 인증 쿠키 포함
  - 에러 핸들링

**예시**:
```javascript
// ✅ 올바른 사용
const { data } = await client.get('/users/me');
// 실제 요청: GET /api/users/me

// ❌ 잘못된 사용
const response = await fetch('/users/me'); // /api 누락!
```

## 3. 예외 상황
- **파일 다운로드**: `<a href="/api/files/123">`
- **외부 API**: fetch() 직접 사용 (client 사용 금지)
- **WebSocket**: `/api/ws` 경로만 지킴

## 4. 백엔드 라우터 작성
Vite 프록시가 `/api` 자동 제거하므로:
```javascript
// ✅ 백엔드에서는 /api 없이 작성
app.get('/auth/login', ...);  // /api/auth/login으로 접근됨
```