### PR TITLE
fix: JSON 파일 생성 버튼 오류 해결

### DIFF
--- a/frontend/src/components/EditorToolbar.jsx
+++ b/frontend/src/components/EditorToolbar.jsx
@@ -23,6 +23,7 @@ export default function EditorToolbar({
   eraserSize,
   onModeChange,
   onClearAll,
+  stageRef, // stageRef prop 추가
   layout = "full",
 }) {
   const Inner = () => (
@@ -62,6 +63,7 @@ export default function EditorToolbar({
           imageUrl={imageUrl}
           sceneId={selectedId}
           layout={layout}
+          stageRef={stageRef} // stageRef prop 전달
         />
       </div>
 

--- a/frontend/src/components/ImageTransformControls.jsx
+++ b/frontend/src/components/ImageTransformControls.jsx
@@ -9,6 +9,7 @@ export default function ImageTransformControls({
   imageUrl,
   sceneId = 1,
   layout = "full",
+  stageRef, // stageRef prop 추가
 }) {
   // Local state for smooth slider drag
   const [localDots, setLocalDots] = React.useState(Number(targetDots) || 2000);

--- a/frontend/src/pages/EditorPage.jsx
+++ b/frontend/src/pages/EditorPage.jsx
@@ -405,6 +405,7 @@ export default function EditorPage({ projectId = DUMMY }) {
           eraserSize={eraserSize}
           onModeChange={handleModeChange}
           onClearAll={handleClearAll}
+          stageRef={stageRef} // stageRef prop 전달
           layout="sidebar"
         />
       </aside>


### PR DESCRIPTION
ImageTransformControls 컴포넌트의 handleJsonGeneration 함수에서
stageRef를 참조하고 있었으나 props로 전달되지 않아
"JSON 생성 중 오류가 발생했습니다" 에러가 발생하던 문제 수정

- ImageTransformControls에 stageRef prop 추가
- EditorToolbar를 통해 stageRef prop 전달 경로 설정
- EditorPage에서 stageRef를 EditorToolbar로
  전달