### PR TITLE
fix: get_conn wrapper 함수(get_db) 추가

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -56,6 +56,12 @@ async def get_conn() -> AsyncIterator[asyncpg.Connection]:
         await _pool.release(conn)
 
 
+async def get_db() -> AsyncIterator[asyncpg.Connection]:
+    """Depends가 사용할 수 있도록 get_conn을 감싸는 래퍼 함수"""
+    async with get_conn() as conn:
+        yield conn
+
+
 async def _ensure_schema(conn: asyncpg.Connection) -> None:
     global _schema_ready
     if _schema_ready:

--- a/backend/app/routers/project.py
+++ b/backend/app/routers/project.py
@@ -1,5 +1,5 @@
 import asyncpg
-from app.db.database import get_conn
+from app.db.database import get_db
 from app.db.project import (
     get_projects_by_user_id,
     create_project,
@@ -26,7 +26,7 @@ router = APIRouter()
 @router.get("", response_model=ProjectListResponse, summary="프로젝트 목록 조회")
 async def list_projects(
     current_user: UserResponse = Depends(get_current_user),
-    conn: asyncpg.Connection = Depends(get_conn),
+    conn: asyncpg.Connection = Depends(get_db),
 ):
     """
     현재 로그인한 사용자의 모든 **프로젝트 목록**을 조회합니다.
@@ -44,7 +44,7 @@ async def list_projects(
 async def create_new_project(
     project: ProjectCreate,
     current_user: UserResponse = Depends(get_current_user),
-    # conn: asyncpg.Connection = Depends(get_conn),
+    conn: asyncpg.Connection = Depends(get_db),
 ):
     """
     새로운 **드론쇼 프로젝트**를 생성합니다.
@@ -56,8 +56,7 @@ async def create_new_project(
     - **max_accel**: 드론의 최대 가속도 (m/s²)
     - **min_separation**: 드론 간 최소 안전 이격 거리 (m)
     """
-    async with get_conn() as conn:
-        new_project_record = await create_project(conn, project, current_user.id)
+    new_project_record = await create_project(conn, project, current_user.id)
     return {"success": True, "project": new_project_record}
 
 
@@ -69,7 +68,7 @@ async def create_new_project(
 async def get_project_details(
     project_id: uuid.UUID,
     current_user: UserResponse = Depends(get_current_user),
-    conn: asyncpg.Connection = Depends(get_conn),
+    conn: asyncpg.Connection = Depends(get_db),
 ):
     """
     특정 **프로젝트의 상세 정보**를 조회합니다. 프로젝트에 포함된 씬 목록도 함께 반환됩니다.
@@ -89,7 +88,7 @@ async def update_existing_project(
     project_id: uuid.UUID,
     project_update: ProjectUpdate,
     current_user: UserResponse = Depends(get_current_user),
-    conn: asyncpg.Connection = Depends(get_conn),
+    conn: asyncpg.Connection = Depends(get_db),
 ):
     """
     특정 **프로젝트의 정보**를 수정합니다. 수정하려는 필드만 요청 본문에 포함하여 전송합니다.
@@ -113,7 +112,7 @@ async def update_existing_project(
 async def delete_existing_project(
     project_id: uuid.UUID,
     current_user: UserResponse = Depends(get_current_user),
-    conn: asyncpg.Connection = Depends(get_conn),
+    conn: asyncpg.Connection = Depends(get_db),
 ):
     """
     특정 **프로젝트를 삭제**합니다.


### PR DESCRIPTION
지금 db 연결방식이 여러 개인데, 차후 하나로 통일하면 좋을 것같습니다. 

### 문제
**기존에 get_conn을 사용할 때**
1. **async with get_conn() as conn: - 정상 작동**
   - get_conn()을 직접 호출하여 context manager를 생성
   - yield conn 후 finally 블록에서 연결을 정리

2. **conn: asyncpg.Connection = Depends(get_conn) - 문제 발생**
   - FastAPI가 get_conn()을 dependency로 처리하려고 시도
   - @asynccontextmanager로 장식된 함수는 generator를 반환하므로 asyncpg.Connection 객체가 아님

### 해결
**wrapper 함수**
```
async def get_db() -> AsyncIterator[asyncpg.Connection]:
    """Database connection dependency for FastAPI"""
    async with get_conn() as conn:
        yield conn
```

**project 쪽 코드**
```
async def create_new_project(
    project: ProjectCreate,
    current_user: UserResponse = Depends(get_current_user),
    conn: asyncpg.Connection = Depends(get_db),
):
    new_project_record = await create_project(conn, project, current_user.id)
    return {"success": True, "project": new_project_record}
```
