### PR TITLE
feat: 프로젝트 설정 모달 추가 및 대시보드/에디터에서 수정 기능 지원

### DIFF
--- a/backend/app/db/project.py
+++ b/backend/app/db/project.py
@@ -76,7 +76,8 @@ async def update_project_by_id(
         # 수정할 내용이 없으면 기존 프로젝트 정보 반환
         return await get_project_by_id(conn, project_id, user_id)
 
-    set_clauses = [f"{key} = ${i+2}" for i, key in enumerate(update_data.keys())]
+    # Placeholders: $1=id, $2=user_id, update fields start at $3
+    set_clauses = [f"{key} = ${i+3}" for i, key in enumerate(update_data.keys())]
     query = f"""
         UPDATE project
         SET {', '.join(set_clauses)}, updated_at = NOW()

--- a/frontend/src/components/ProjectSettingsModal.jsx
+++ b/frontend/src/components/ProjectSettingsModal.jsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from "react";
+import client from "../api/client";
+
+export default function ProjectSettingsModal({ project, onClose, onSaved }) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const [form, setForm] = useState({
+    project_name: "",
+    max_scene: 0,
+    max_speed: 0,
+    max_accel: 0,
+    min_separation: 0,
+  });
+
+  useEffect(() => {
+    if (project) {
+      setForm({
+        project_name: project.project_name ?? "",
+        max_scene: project.max_scene ?? 0,
+        max_speed: project.max_speed ?? 0,
+        max_accel: project.max_accel ?? 0,
+        min_separation: project.min_separation ?? 0,
+      });
+    }
+  }, [project]);
+
+  const updateField = (key) => (e) => {
+    const val = e.target.value;
+    setForm((prev) => ({
+      ...prev,
+      [key]: key === "project_name" ? val : val === "" ? "" : Number(val),
+    }));
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    setError("");
+    if (!project?.id) return;
+
+    // Basic validation
+    if (!form.project_name) {
+      setError("프로젝트 이름을 입력하세요.");
+      return;
+    }
+
+    const numericKeys = ["max_scene", "max_speed", "max_accel", "min_separation"]; 
+    for (const k of numericKeys) {
+      if (form[k] === "" || Number.isNaN(Number(form[k]))) {
+        setError("수치 항목은 숫자로 입력하세요.");
+        return;
+      }
+    }
+
+    const payload = {
+      project_name: form.project_name,
+      max_scene: Number(form.max_scene),
+      max_speed: Number(form.max_speed),
+      max_accel: Number(form.max_accel),
+      min_separation: Number(form.min_separation),
+    };
+
+    try {
+      setSaving(true);
+      const { data } = await client.put(`/projects/${project.id}`, payload, {
+        headers: { "Content-Type": "application/json" },
+      });
+      if (data?.success && data?.project) {
+        onSaved?.(data.project);
+        onClose?.();
+      } else {
+        setError("저장에 실패했습니다. 다시 시도하세요.");
+      }
+    } catch (err) {
+      const msg = err?.response?.data?.detail || "저장 중 오류가 발생했습니다.";
+      setError(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Close on ESC
+  useEffect(() => {
+    const onKey = (e) => e.key === "Escape" && onClose?.();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-[70] grid place-items-center p-4 bg-black/30">
+      <div className="w-full max-w-lg rounded-2xl bg-white shadow-xl ring-1 ring-black/5 overflow-hidden">
+        <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b">
+          <h3 className="text-xl font-bold">프로젝트 설정</h3>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded p-1 text-gray-500 hover:bg-gray-100"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSave} className="px-5 py-4 space-y-3">
+          <div>
+            <label className="block text-sm font-medium mb-1">프로젝트 이름</label>
+            <input
+              type="text"
+              value={form.project_name}
+              onChange={updateField("project_name")}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+              placeholder="프로젝트 이름"
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block">
+              <div className="text-sm font-medium mb-1">max_scene</div>
+              <input
+                type="number"
+                inputMode="numeric"
+                value={form.max_scene}
+                onChange={updateField("max_scene")}
+                className="w-full rounded border border-gray-300 px-3 py-2"
+                min={0}
+              />
+            </label>
+            <label className="block">
+              <div className="text-sm font-medium mb-1">max_speed</div>
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.1"
+                value={form.max_speed}
+                onChange={updateField("max_speed")}
+                className="w-full rounded border border-gray-300 px-3 py-2"
+                min={0}
+              />
+            </label>
+            <label className="block">
+              <div className="text-sm font-medium mb-1">max_accel</div>
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.1"
+                value={form.max_accel}
+                onChange={updateField("max_accel")}
+                className="w-full rounded border border-gray-300 px-3 py-2"
+                min={0}
+              />
+            </label>
+            <label className="block">
+              <div className="text-sm font-medium mb-1">min_separation</div>
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.1"
+                value={form.min_separation}
+                onChange={updateField("min_separation")}
+                className="w-full rounded border border-gray-300 px-3 py-2"
+                min={0}
+              />
+            </label>
+          </div>
+
+          {error && (
+            <div className="text-red-600 text-sm" role="alert">{error}</div>
+          )}
+
+          <div className="pt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded px-4 py-2 border border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded px-4 py-2 bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              {saving ? "저장 중..." : "저장"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## 변경 사항

### Backend
- **`app/db/project.py`**
  - `update_project_by_id`의 SQL placeholder 인덱스 수정  
    (`$2 → $3`부터 시작하도록 조정)

### Frontend
- **`components/ProjectSettingsModal.jsx`**
  - 신규 추가
  - 프로젝트 이름, max_scene, max_speed, max_accel, min_separation 수정 가능
  - ESC 키 닫기, 기본 validation 및 에러 메시지 처리
  - 저장 성공 시 `onSaved`, `onClose` 콜백 실행

- **`pages/DashboardPage.jsx`**
  - 프로젝트 카드에 **설정 버튼(CiMenuBurger)** 추가
  - `editingProject` 상태로 모달 열기/닫기 지원
  - 저장 완료 시 해당 프로젝트 리스트 업데이트
  - 기본 새 프로젝트 이름 `"새 프로젝트"`로 변경

- **`pages/EditorPage.jsx`**
  - 에디터 페이지 하단에 **프로젝트 설정 버튼(CiSettings)** 추가
  - `projectMeta` 상태 저장 및 서버 fetch 결과 반영
  - 설정 저장 시 프로젝트 메타 및 이름 즉시 업데이트

## 기능 요약
- 대시보드 및 에디터에서 **프로젝트 설정 모달**을 열어 프로젝트 메타데이터를 수정할 수 있음
- 프로젝트명 및 제약 수치(max_scene, speed, accel, separation) 관리 가능
- 백엔드/프론트엔드 동기화 완료
