### PR TITLE
feat(auth): 이메일 인증(Email verification) 기능 추가

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -16,3 +16,17 @@ ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
 
 def get_access_token_expiry() -> timedelta:
     return timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+
+# Email verification token expiry (hours)
+EMAIL_VERIFY_EXPIRE_HOURS = int(os.getenv("EMAIL_VERIFY_EXPIRE_HOURS", "24"))
+
+# Service URLs
+BACKEND_BASE_URL = os.getenv("BACKEND_BASE_URL", "http://localhost:8000")
+
+# SMTP settings
+SMTP_HOST = os.getenv("SMTP_HOST", "")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_STARTTLS = os.getenv("SMTP_STARTTLS", "true").lower() in ("1", "true", "yes")
+SMTP_USERNAME = os.getenv("SMTP_USERNAME", "")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "")
+SMTP_FROM = os.getenv("SMTP_FROM", "no-reply@localhost")

--- a/backend/app/db/WDSS.sql
+++ b/backend/app/db/WDSS.sql
@@ -4,6 +4,7 @@ CREATE TABLE "users" (
   "id" uuid PRIMARY KEY,
   "email" varchar(32) UNIQUE,
   "username" varchar(32) UNIQUE,
+  "is_email_verified" boolean NOT NULL DEFAULT false,
   "status" varchar(16) NOT NULL DEFAULT 'ACTIVE',
   "last_login_at" timestamptz,
   "created_at" timestamptz NOT NULL DEFAULT (now()),

--- a/backend/app/utils/mailer.py
+++ b/backend/app/utils/mailer.py
@@ -1,0 +1,28 @@
+import smtplib
+from email.message import EmailMessage
+
+from app.core import config
+
+
+def send_email(to_email: str, subject: str, text_body: str) -> None:
+    """Send an email via SMTP. If SMTP not configured, print to stdout as fallback."""
+    if not config.SMTP_HOST or not to_email:
+        # Fallback to console for non-configured environments
+        print("[MAIL:FALLBACK] To:", to_email)
+        print("[MAIL:FALLBACK] Subject:", subject)
+        print("[MAIL:FALLBACK] Body:\n", text_body)
+        return
+
+    msg = EmailMessage()
+    msg["From"] = config.SMTP_FROM
+    msg["To"] = to_email
+    msg["Subject"] = subject
+    msg.set_content(text_body)
+
+    with smtplib.SMTP(config.SMTP_HOST, config.SMTP_PORT) as server:
+        if config.SMTP_STARTTLS:
+            server.starttls()
+        if config.SMTP_USERNAME:
+            server.login(config.SMTP_USERNAME, config.SMTP_PASSWORD)
+        server.send_message(msg)
+


### PR DESCRIPTION
## 변경 사항
- Backend
  - `users` 테이블에 `is_email_verified boolean NOT NULL DEFAULT false` 컬럼 추가
    - 신규 스키마(`backend/app/db/WDSS.sql`)에 반영
    - 기존 DB에 대해 부트 시 자동 추가하도록 `_ensure_schema` 보완 (`backend/app/db/database.py`)
  - 환경설정 확장 (`backend/app/core/config.py`)
    - `EMAIL_VERIFY_EXPIRE_HOURS` (기본 24h)
    - `BACKEND_BASE_URL` (검증 링크 생성용, 기본 `http://localhost:8000`)
    - SMTP 관련 설정: `SMTP_HOST`, `SMTP_PORT`, `SMTP_STARTTLS`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`
  - 메일 발송 유틸 추가 (`backend/app/utils/mailer.py`)
    - SMTP 미설정 시 콘솔 출력(FALLBACK)으로 대체
  - 이메일 검증 토큰 생성/검증 로직 추가 (`backend/app/utils/security.py`)
    - 목적(`purpose: email-verify`)과 만료(exp) 내장
  - 인증 라우터 확장 (`backend/app/routers/auth.py`)
    - 회원가입 시 검증 메일 발송
    - `GET /auth/verify?token=...` 추가: 토큰 검증 후 `users.is_email_verified = TRUE` 업데이트
- Frontend
  - 해당 PR에는 변경 없음

---

## 기능 요약
- 회원가입 시 이메일 검증 링크를 발송합니다.
  - SMTP 설정이 없으면 터미널/로그에 FALLBACK 메시지로 링크를 출력합니다.
- 사용자가 검증 링크(`GET /auth/verify?token=...`)를 열면 이메일이 검증 상태로 변경됩니다.
- 토큰은 목적(purpose)과 만료시간을 포함하여 안전하게 처리됩니다.

---

## 테스트 방법
1) 환경 변수 설정 (.env 예시)
```bash
# 백엔드 기본 URL (검증 링크 생성에 사용)
BACKEND_BASE_URL=http://localhost:8000

# 이메일 검증 토큰 만료(시간)
EMAIL_VERIFY_EXPIRE_HOURS=24

# SMTP 미사용 시 아래는 비워두면 콘솔 FALLBACK 로 동작
SMTP_HOST=
SMTP_PORT=587
SMTP_STARTTLS=true
SMTP_USERNAME=
SMTP_PASSWORD=
SMTP_FROM=no-reply@localhost
```

2) 서버 실행 후 회원가입 요청
```bash
# 예: FastAPI 서버 실행 중
# 회원가입
curl -X POST http://localhost:8000/auth/register \  -H "Content-Type: application/json" \  -d '{"email":"test@example.com","username":"tester","password":"Passw0rd!"}'
```
- SMTP 미설정 시 서버 터미널에 아래와 유사한 FALLBACK 로그가 출력됩니다.
  - `[MAIL:FALLBACK] To: test@example.com`
  - `[MAIL:FALLBACK] Subject: Verify your email`
  - `http://localhost:8000/auth/verify?token=...`

3) 검증 링크 호출
```bash
# 위 로그의 링크를 복사하여 브라우저로 열거나:
curl "http://localhost:8000/auth/verify?token=붙여넣기"
```
- 응답: `{"success": true, "message": "Email verified successfully"}`

4) DB 확인 (선택)
```sql
SELECT id, email, is_email_verified FROM users WHERE email = 'test@example.com';
```
- `is_email_verified` 가 `true` 로 업데이트되어야 합니다.

5) 에러/엣지 케이스
- 만료된 토큰 → 400 `Invalid or expired token`
- 목적이 다른 토큰/변조된 토큰 → 400
- 중복 회원가입 → 409 `Email or username already exists`

---

## 참고 사항
- 변경 파일(총 6):
  - `backend/app/core/config.py` (+)
  - `backend/app/db/WDSS.sql` (+ 컬럼)
  - `backend/app/db/database.py` (+ 자동 컬럼 추가)
  - `backend/app/routers/auth.py` (+ 메일 발송 및 /auth/verify)
  - `backend/app/utils/mailer.py` (신규)
  - `backend/app/utils/security.py` (+ 이메일 검증 토큰)
- 스키마 마이그레이션
  - 프로덕션에서는 정식 마이그레이션 도구 도입(예: Alembic) 고려
  - 현 PR은 부트 시 컬럼 유무 검사 후 `ALTER TABLE`로 보완
- 기능 범위
  - 현재 로그인 차단(미검증 사용자 로그인 불가 여부)은 본 PR에 포함하지 않음
    - 필요 시 로그인 시점에 `is_email_verified` 확인 추가 예정
