### PR TITLE
hotfix: 환경변수 로딩 및 `DATABASE_URL` 기본값/정규화 수정

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgresql://wdss_user:1234@127.0.0.1:5432/wdss
+DATABASE_URL=postgresql://postgres:1234@localhost:5432/wdss

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -4,10 +4,22 @@ import asyncpg
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 from asyncpg import exceptions as pgexc
+from dotenv import load_dotenv
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL", "postgresql://postgres:1234@localhost:5432/wdss"
-)
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if not DATABASE_URL:
+    DB_HOST = os.getenv("DB_HOST", "localhost")
+    DB_PORT = os.getenv("DB_PORT", "5432")
+    DB_NAME = os.getenv("DB_NAME", "wdss")
+    DB_USER = os.getenv("DB_USER", "postgres")
+    DB_PASSWORD = os.getenv("DB_PASSWORD", "1234")
+    DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+if DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
 
 _pool: asyncpg.Pool | None = None
 _schema_ready: bool = False


### PR DESCRIPTION
## 요약 (What & Why)
- **문제**: 로컬/서버 환경에서 `DATABASE_URL` 미설정 또는 `postgres://` 스킴 사용 시 연결 실패/경고 발생.
- **해결**:
  - `python-dotenv`로 `.env` 파일 로드(`load_dotenv()` 추가).
  - `postgres://` → `postgresql://`로 자동 정규화.
  - `DATABASE_URL`이 없으면 개별 변수(`DB_HOST/PORT/NAME/USER/PASSWORD`)로 안전한 **fallback** 구성.
  - 로컬 기본값을 일관되게 `postgresql://postgres:1234@localhost:5432/wdss`로 정리.

## 변경 사항 (Diff Overview)
- `backend/.env`
  - `DATABASE_URL=postgresql://wdss_user:1234@127.0.0.1:5432/wdss`
  - → `DATABASE_URL=postgresql://postgres:1234@localhost:5432/wdss` 로 통일
- `backend/app/db/database.py`
  - `load_dotenv()` 추가로 `.env` 자동 로딩
  - `DATABASE_URL` 미존재 시 개별 환경변수 기반 DSN 조립
  - `postgres://` 스킴을 `postgresql://`로 치환

## 상세 설명
- **호환성**: 기존 `postgres://` DSN을 사용하는 배포 환경에서도 코드가 자동으로 `postgresql://`로 변환하여 연결합니다.
- **안전성**: 직접적인 커넥션 풀 구성 전 단계에서 DSN을 확정하여 런타임 오류를 줄입니다.
- **개발 편의**: `.env` 없이도 합리적인 기본값으로 동작하여 온보딩/세팅 시간을 줄입니다.