### PR TITLE
feat: project delete 기능 구현 (Dashboard에서 삭제 UI/동작 + 백엔드 안전 삭제 트랜잭션)

### DIFF
--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import "../styles/DashboardPage.css"; // 스타일 import
 import "../styles/DashboardPage.css";
 import { CiMenuBurger } from "react-icons/ci";
+import { TiDelete } from "react-icons/ti";
 import ProjectSettingsModal from "../components/ProjectSettingsModal";
 
 
@@ -100,6 +101,19 @@ export default function DashboardPage() {
     setProjects((prev) => prev.map((p) => (p.id === updated.id ? { ...p, ...updated } : p)));
   };
 
+  const handleDeleteProject = async (e, projectId, projectName) => {
+    e.stopPropagation();
+    const ok = window.confirm(`프로젝트 "${projectName}"를 삭제할까요? 이 작업은 되돌릴 수 없습니다.`);
+    if (!ok) return;
+    try {
+      await client.delete(`/projects/${projectId}`);
+      setProjects((prev) => prev.filter((p) => p.id !== projectId));
+    } catch (err) {
+      console.error("Failed to delete project:", err);
+      alert("프로젝트 삭제에 실패했습니다.");
+    }
+  };
+
   const formatDate = (dateString) => {
     const options = { year: "numeric", month: "long", day: "numeric" };
     return new Date(dateString).toLocaleDateString("ko-KR", options);
@@ -147,6 +161,15 @@ export default function DashboardPage() {
                       (e.key === "Enter" || e.key === " ") && handleProjectClick(project.id)
                     }
                   >
+                    {/* Hover delete button */}
+                    <button
+                      className="project-delete-btn"
+                      title="프로젝트 삭제"
+                      aria-label={`삭제: ${project.project_name}`}
+                      onClick={(e) => handleDeleteProject(e, project.id, project.project_name)}
+                    >
+                      <TiDelete size={22} />
+                    </button>
                     <div className="card-thumbnail">
                       <ProjectIcon />
                     </div>
@@ -187,4 +210,3 @@ export default function DashboardPage() {
     </>
   );
 }
-

--- a/frontend/src/styles/DashboardPage.css
+++ b/frontend/src/styles/DashboardPage.css
@@ -93,6 +93,7 @@
   display: flex;
   flex-direction: column;
   outline: none;
+  position: relative; /* for hover actions */
 }
 .project-card:hover {
   transform: translateY(-4px);
@@ -113,6 +114,36 @@
 .card-body {
   padding: 16px 20px;
   flex-grow: 1;
+}
+
+/* Hover delete button */
+.project-delete-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #dc2626;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.project-card:hover .project-delete-btn,
+.project-delete-btn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.project-delete-btn:hover {
+  background: #fee2e2;
 }
 
 .card-title {


### PR DESCRIPTION
## 변경 사항
- **Backend (backend/app/db/project.py)**
  - `delete_project_by_id`를 트랜잭션 기반으로 리팩터링
    - `project_scenes`에서 프로젝트-씬 관계 행 삭제
    - 참조되지 않는 `scene` 데이터 자동 정리
    - 마지막으로 `user_id` 기준으로 프로젝트 삭제 수행
- **Frontend (frontend/src/pages/DashboardPage.jsx)**
  - 대시보드 프로젝트 카드 Hover 시 삭제 버튼(`TiDelete`) 노출
  - `handleDeleteProject` 핸들러 추가 (확인 다이얼로그 → API 호출 → 상태 업데이트)
  - 접근성 개선: 삭제 버튼에 `title`, `aria-label` 속성 추가
- **Frontend (frontend/src/styles/DashboardPage.css)**
  - `.project-card`에 `position: relative` 적용
  - `.project-delete-btn` 스타일 추가 및 Hover/Focus 시 표시

---

## 기능 요약
- 대시보드에서 프로젝트 삭제 가능
- 삭제 시 프로젝트-씬 관계 및 고아 Scene 자동 정리
- UI에서 프로젝트 카드 Hover 시 삭제 버튼 표시 및 즉시 반영
