### PR TITLE
feat: JSON export 기능 구현 및 새 창 열림 제거

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -99,8 +99,11 @@ export default function Navbar({ transparent: propTransparent = false }) {
           const full = json_url.startsWith("http")
             ? json_url
             : `${base}/${json_url.replace(/^\//, "")}`;
-          try { setJsonBuilt(true); setLastJsonUrl(full); } catch {}
-          window.open(full, "_blank", "noopener");
+          try {
+            setJsonBuilt(true);
+            setLastJsonUrl(full);
+          } catch {}
+          // window.open(full, "_blank", "noopener");
 
           alert(
             unity_sent
@@ -164,17 +167,23 @@ export default function Navbar({ transparent: propTransparent = false }) {
               <button
                 onClick={() => {
                   if (!transformClicked || !jsonBuilt) {
-                    alert("먼저 '변환' 버튼과 'JSON 파일로만들기' 버튼을 순서대로 실행해 주세요.");
+                    alert(
+                      "먼저 '변환' 버튼과 'JSON 파일로만들기' 버튼을 순서대로 실행해 주세요."
+                    );
                     return;
                   }
                   if (!lastJsonUrl) {
-                    alert("다운로드할 JSON URL이 없습니다. 'JSON 파일로만들기'를 먼저 실행해 주세요.");
+                    alert(
+                      "다운로드할 JSON URL이 없습니다. 'JSON 파일로만들기'를 먼저 실행해 주세요."
+                    );
                     return;
                   }
                   try {
-                    const a = document.createElement('a');
+                    const a = document.createElement("a");
                     a.href = lastJsonUrl;
-                    a.download = `${(editorState.projectName || 'project').replace(/[^\\w.-]+/g, '_')}.json`;
+                    a.download = `${(
+                      editorState.projectName || "project"
+                    ).replace(/[^\\w.-]+/g, "_")}.json`;
                     document.body.appendChild(a);
                     a.click();
                     document.body.removeChild(a);


### PR DESCRIPTION
## 변경 사항
- **Frontend (Navbar.jsx)**
  - JSON export 관련 상태 추가
    - `transformClicked`, `jsonBuilt`, `lastJsonUrl` 상태값 관리
  - `handleTransform` 실행 시 상태 초기화 및 클릭 여부 관리 로직 추가
  - JSON 변환 완료 시 `jsonBuilt` 갱신 및 `lastJsonUrl` 저장
  - 기존 `window.open` 방식 제거 → JSON 생성 후 Export 버튼을 눌렀을 때만 다운로드 링크 생성
  - Export 버튼 클릭 시:
    - `transform` 및 `JSON 파일로 만들기` 실행 여부 확인 후 다운로드 허용
    - `lastJsonUrl` 기반으로 JSON 파일 다운로드 링크 생성 및 클릭 이벤트 트리거
  - UI 버튼 추가: `"Export"` 버튼 및 예외 처리(alert 메시지)

---

## 기능 요약
- **JSON Export 기능 추가**
  - `변환` → `JSON 파일로만들기` → `Export` 버튼 순서로 JSON 파일 다운로드 가능
- **불필요한 새 창 열림 제거**
  - 기존 `window.open` 대신 실제 `.json` 파일 다운로드 기능으로 변경
- **사용성 개선**
  - 올바른 순서로 버튼을 누르지 않으면 안내 메시지 표시
