### PR TITLE
fix: 시작 시 그리기가 아닌 선택도구로 시작

### DIFF
--- a/frontend/src/components/Canvas.jsx
+++ b/frontend/src/components/Canvas.jsx
@@ -128,6 +128,14 @@ export default function Canvas({
     brush.decimate = 2; // 브러시 포인트 간소화
     brush.limitedToCanvasSize = true; // 캔버스 경계 제한
     canvas.freeDrawingBrush = brush;
+    // 초기 외부 모드가 드로잉이 아니면 즉시 비활성화하여 첫 클릭에 선이 그려지지 않도록 함
+    try {
+      if (!(externalDrawingMode === 'draw' || externalDrawingMode === 'pixelErase')) {
+        canvas.isDrawingMode = false;
+        canvas.selection = (externalDrawingMode === 'select');
+        canvas.skipTargetFind = externalDrawingMode === 'draw' || externalDrawingMode === 'pixelErase' || externalDrawingMode === 'erase' || externalDrawingMode === 'brush';
+      }
+    } catch (_) {}
     fabricCanvas.current = canvas;
 
     if (externalStageRef) {

--- a/frontend/src/pages/EditorPage.jsx
+++ b/frontend/src/pages/EditorPage.jsx
@@ -63,7 +63,7 @@ export default function EditorPage({ projectId = DUMMY }) {
   const galleryRef = useRef(null);
 
   // 캔버스 관련 상태
-  const [drawingMode, setDrawingMode] = useState("draw");
+  const [drawingMode, setDrawingMode] = useState("select");
   const [eraserSize, setEraserSize] = useState(20);
   const [drawingColor, setDrawingColor] = useState('#222222');
   const [selectedObject, setSelectedObject] = useState(null);
@@ -150,6 +150,12 @@ export default function EditorPage({ projectId = DUMMY }) {
       
       if (stageRef.current && stageRef.current.layers) {
         setCanvasReady(true);
+        // 초기 진입 시 도구를 클릭(선택) 모드로 강제 설정
+        try {
+          if (stageRef.current.setDrawingMode) {
+            stageRef.current.setDrawingMode('select');
+          }
+        } catch (_) {}
         updateLayerState();
         
         // 캔버스 선택 이벤트 리스너 추가


### PR DESCRIPTION
# PR: 에디터 초기 진입 기본 도구를 ‘선택’으로 변경 및 초기 그리기 비활성화

## 개요

* 에디터 진입 시 기본 도구가 **펜(draw)** 으로 설정되어 있어, 첫 클릭 시 의도치 않게 선이 그려지는 문제 발생
* 초기 상태를 **선택(select) 모드**로 고정
* 캔버스 초기화 과정에서도 드로잉이 켜지지 않도록 **안전장치 추가**

---

## 변경 사항

### 📂 `frontend/src/pages/EditorPage.jsx`

* `drawingMode` 초기값을 `"select"`로 변경
* 캔버스 준비 완료 시 `stageRef.current.setDrawingMode('select')` 호출로 초기 모드 확정

### 📂 `frontend/src/components/Canvas.jsx`

* 브러시 생성 직후, 외부 모드가 드로잉 계열이 아니면 즉시 `canvas.isDrawingMode = false` 전환
* 초기 프레임에서 펜이 잠깐 활성화되는 **깜빡임 현상 방지**

---

## 기대 동작

* 에디터 진입 직후 → **선택 모드가 기본**, 캔버스 클릭/드래그 시 선이 그려지지 않음
* 도구 전환 → 기존과 동일하게 `draw/brush/erase/pixelErase` 전환 가능
* 씬 전환 및 캔버스 재마운트 시에도 **기본은 Select 모드 유지**

---

## 테스트 방법

1. 에디터 페이지 진입 후, 캔버스 클릭/드래그 → 아무것도 그려지지 않아야 함
2. 도구를 Draw로 전환 후 선을 그림 → 다시 Select로 전환 후 클릭 시, 그려지지 않아야 함
3. 씬을 바꾸거나 새로고침 후에도 기본 모드가 Select인지 확인

---

## 영향 범위

* 기존 드로잉 / 브러시 / 지우개 도구 기능 및 색상 변경 흐름에는 영향 없음
* 코드에서 `setDrawingMode`를 호출하는 경우에도 정상 동작 유지

---

