### PR TITLE
hotfix: 유니티 통신 버그 수정

### DIFF
--- a/backend/app/routers/project.py
+++ b/backend/app/routers/project.py
@@ -236,7 +236,7 @@ async def export_project_to_json(
 
     # 프로젝트 레벨 JSON 구성 (무조건 DB 값 사용)
     project_json = {
-        "format": project["format"] or "dsj",
+        "format": (project["format"] or "dsj").strip(),
         "show": {
             "show_name": project["project_name"] or "Untitled Show",
             "max_scene": int(project["max_scene"] or 1),

--- a/backend/app/routers/websocket.py
+++ b/backend/app/routers/websocket.py
@@ -1,6 +1,7 @@
 import json # JSON 라이브러리 import
 from typing import List
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 
 # (ConnectionManager 클래스는 변경 없음)
 class ConnectionManager:
@@ -37,3 +38,10 @@ async def websocket_endpoint(websocket: WebSocket):
     except WebSocketDisconnect:
         manager.disconnect(websocket)
         await manager.broadcast("A client has left the chat")
+
+
+@router.post("/test/broadcast")
+async def test_broadcast():
+    test_message = "Test message from backend"
+    await manager.broadcast(test_message)
+    return {"status": "success", "message": "Test message broadcasted to all connected Unity clients"}


### PR DESCRIPTION
const response = await client.post('/ws/test/broadcast', {});
  ❌ 백엔드에 /ws/test/broadcast 엔드포인트가 없었음
  ✅ 해결: websocket.py에 엔드포인트 추가

"format": "dsj                                                             "
  ❌ Unity에서 format 검증 실패
  ✅ 해결: project.py에서 .strip() 추가