### PR TITLE
feat: 에디터 페이지 캔버스 썸네일 활성화

### DIFF
--- a/frontend/src/components/MainCanvasSection.jsx
+++ b/frontend/src/components/MainCanvasSection.jsx
@@ -6,6 +6,7 @@ function MainCanvasSection({
   imageUrl,
   stageRef,
   onChange,
+  onPreviewChange,
   drawingMode,
   eraserSize,
   drawingColor,
@@ -43,6 +44,7 @@ function MainCanvasSection({
               width={1200}
               height={675}
               onChange={(patch) => onChange(selectedScene.id, patch)}
+              onPreviewChange={onPreviewChange}
               imageUrl={imageUrl}
               stageRef={stageRef}
               drawingMode={drawingMode}

--- a/frontend/src/components/SceneCarousel.jsx
+++ b/frontend/src/components/SceneCarousel.jsx
@@ -305,7 +305,7 @@ export default React.memo(function SceneCarousel({
         style={{
           width: dims.thumbW,
           height: dims.thumbH,
-          background: item.preview ? `url(${item.preview})` : "#ddd",
+          background: (item.preview || item.imageUrl) ? `url(${item.preview || item.imageUrl})` : "#ddd",
           backgroundSize: "cover",
           backgroundPosition: "center",
           borderRadius: 8,

--- a/frontend/src/pages/EditorPage.jsx
+++ b/frontend/src/pages/EditorPage.jsx
@@ -945,6 +945,10 @@ const handleClearAll = React.useCallback(async () => {
               imageUrl={imageUrl}
               stageRef={stageRef}
               onChange={handleSceneChange}
+              onPreviewChange={(dataUrl) => {
+                if (!dataUrl || !selectedId) return;
+                setScenes(prev => prev.map(s => s.id === selectedId ? { ...s, preview: dataUrl } : s));
+              }}
               drawingMode={drawingMode}
               eraserSize={eraserSize}
               drawingColor={drawingColor}


### PR DESCRIPTION
# 에디터 씬 썸네일에 캔버스 요소(드로잉/객체) 실시간 미리보기 반영

## 요약
- 하단 씬 캐러셀 썸네일이 이제 **캔버스의 실제 상태(드로잉/지우개, 드롭한 이미지, SVG 점 등)** 를 반영해 자동으로 갱신됩니다.  
- 초기에는 **베이스 이미지(imageUrl, s3_key 기반)** 가 보이고, 사용자가 편집하면 **캔버스 스냅샷**으로 자연스럽게 대체됩니다.

---

## 변경 사항

### `Canvas.jsx`
- `onPreviewChange` 콜백 추가  
- 캔버스 이벤트 발생 시 `toDataURL()`로 PNG 스냅샷 생성 → 상위 컴포넌트로 전달 (200ms 디바운스)  
- 미리보기 트리거:
  - `object:added/modified/removed`
  - `path:created`
  - 배경 이미지 로드 완료
  - 이미지 드롭 후
  - 전체 지우기 이벤트

### `MainCanvasSection.jsx`
- `onPreviewChange` 프롭을 받아 `Canvas`로 전달.

### `EditorPage.jsx`
- `onPreviewChange` 구현: 현재 선택된 씬의 `preview` 필드를 data URL로 갱신 → 캐러셀 즉시 반영.

### `SceneCarousel.jsx`
- 썸네일 배경을 `item.preview || item.imageUrl` 로 표시  
- 미리보기 없을 때는 **베이스 이미지**를 폴백으로 사용.

---

## 동작 방식
1. 에디터에서 드로잉/객체 추가·이동·삭제/클리어 발생  
2. 캔버스가 200ms 디바운스로 `toDataURL()` PNG 스냅샷 생성  
3. `EditorPage`가 선택된 씬의 `preview` 상태 갱신  
4. 캐러셀이 해당 씬 썸네일을 즉시 업데이트  
5. 새 씬은 초기에는 `imageUrl`(있다면) 표시 → 편집 시 `preview`로 대체  

---

## UI/UX
- 썸네일 스타일은 그대로 유지, 콘텐츠만 **실시간 반영**  
- 갤러리 컴팩트 모드에서도 동일하게 동작  

---

## 성능/안정성
- 200ms 디바운스로 과도한 스냅샷 생성을 방지  
- 현재 `toDataURL({ multiplier: 1, quality: 0.92 })` 적용  
- 필요 시 다운스케일(`multiplier < 1`) 적용 가능  
- 대형 캔버스/빈번한 수정 → 업데이트 빈도 조정 여지 있음  

---

## 호환성
- 서버 API 변경 없음  
- 클라이언트 상태(`scenes[].preview`)만 추가 사용  
- 기존 씬 로딩/삭제/정렬 기능 영향 없음  

---

## 테스트 방법
1. 에디터에서 프로젝트/씬 열기  
2. 브러시로 드로잉 → 씬 썸네일 반영 확인  
3. 이미지 갤러리에서 캔버스로 드래그 앤 드롭 → 썸네일 반영 확인  
4. 지우개/전체 지우기 → 썸네일 반영 확인  
5. 씬 추가/선택 변경 시:
   - 새 씬은 초기엔 `imageUrl` 표시
   - 편집 시 `preview`로 대체  
6. 씬 이동/정렬 시 썸네일·선택 상태 정상 표시  
7. 갤러리 컴팩트 모드 → 썸네일 정상 표시 확인  
8. 창 사이즈 변경 시 레이아웃 문제 없는지 확인  

---

## 알려진 제한
- 미리보기는 **클라이언트 상태(data URL)** 로만 유지  
- 페이지 새로고침 후에는 서버의 `imageUrl`로 폴백  
- 필요 시 **백엔드에 preview 저장 API** 추가해 영속화 가능  
- 매우 큰 캔버스/잦은 변경 시 CPU·메모리 사용 일시 증가 가능  

---

## 향후 개선 아이디어
- 썸네일 전용 다운스케일(`multiplier: 0.3`) 적용 → 메모리/전송 최적화  
- 서버에 preview 업로드·저장 → 팀 공유/재방문 시 동일 썸네일 표시  
- 이벤트 폭주 시 썸네일 생성 취소/합치기(coalesce) 로직 추가  
- 썸네일에 선택 경계선/도구 오버레이 제외 옵션  

---

## 변경 파일
- `frontend/src/components/Canvas.jsx`  
- `frontend/src/components/MainCanvasSection.jsx`  
- `frontend/src/pages/EditorPage.jsx`  
- `frontend/src/components/SceneCarousel.jsx`  

---

## 체크리스트
- [x] 기능 동작 수동 테스트  
- [x] 기존 씬 CRUD/정렬 영향 없음 확인  
- [x] 폴백(미리보기 없음 → imageUrl) 확인  
- [x] 성능(대형 캔버스) 스트레스 테스트  
- [ ] 썸네일 다운스케일 옵션 논의  

---

## 롤백 계획
- `onPreviewChange` 경로 제거  
- `SceneCarousel`의 배경을 기존 `item.preview` 대신 서버 필드만 사용하도록 수정  
- 롤백 시 즉시 원상태 복구 가능
