### PR TITLE
Fix/unit select

### DIFF
--- a/frontend/src/contexts/UnityContext.jsx
+++ b/frontend/src/contexts/UnityContext.jsx
@@ -15,6 +15,18 @@ export const UnityProvider = ({ children }) => {
   const [isUnityVisible, setIsUnityVisible] = useState(false);
 
   const showUnity = () => {
+    try {
+      const canvas = window?.editorAPI?.stageRef?.current;
+      if (canvas && typeof canvas.discardActiveObject === 'function') {
+        const actives = typeof canvas.getActiveObjects === 'function' ? canvas.getActiveObjects() : [];
+        if (actives && actives.length > 0) {
+          // Deselect any currently-selected objects to avoid floating UI over the Unity modal
+          try { canvas.discardActiveObject(); } catch (_) {}
+          try { canvas.requestRenderAll && canvas.requestRenderAll(); } catch (_) {}
+        }
+      }
+    } catch (_) {}
+
     setIsUnityVisible(true);
     // Try to reactivate Unity when showing
     setTimeout(() => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,6 +10,7 @@
 @theme {
   --font-tway: "TwaySky", ui-sans-serif, system-ui, sans-serif;
 }
+
 @font-face {
   font-family: "YUniverse";
   src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_yuniverse@1.0/YUniverse-L.woff2")
@@ -34,41 +35,37 @@
   font-weight: 400;
   font-style: normal;
 }
-
 @font-face {
   font-family: "NanumHuman";
   src: url("/fonts/NanumHumanLight.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
-
 @font-face {
   font-family: "NanumHuman";
   src: url("/fonts/NanumHumanBold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
 }
-
 @font-face {
   font-family: "NanumHuman";
   src: url("/fonts/NanumHumanEB.woff") format("woff");
   font-weight: 800;
   font-style: normal;
 }
-
 @font-face {
   font-family: "NanumHuman";
   src: url("/fonts/NanumHumanHeavy.woff") format("woff");
   font-weight: 900;
   font-style: normal;
 }
-
 @font-face {
   font-family: "NanumHuman";
   src: url("/fonts/NanumHumanEL.woff") format("woff");
   font-weight: 200;
   font-style: normal;
 }
+
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Thin.woff")
@@ -76,7 +73,6 @@
   font-weight: 100;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-ExtraLight.woff")
@@ -84,7 +80,6 @@
   font-weight: 200;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Light.woff")
@@ -92,7 +87,6 @@
   font-weight: 300;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
@@ -100,7 +94,6 @@
   font-weight: 400;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff")
@@ -108,7 +101,6 @@
   font-weight: 500;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff")
@@ -116,7 +108,6 @@
   font-weight: 600;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff")
@@ -124,7 +115,6 @@
   font-weight: 700;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-ExtraBold.woff")
@@ -132,7 +122,6 @@
   font-weight: 800;
   font-display: swap;
 }
-
 @font-face {
   font-family: "Pretendard";
   src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Black.woff")
@@ -140,7 +129,8 @@
   font-weight: 900;
   font-display: swap;
 }
-/* 遺?쒕읇寃??됱씠 ?먮Ⅴ?꾨줉 */
+
+/* 그라디언트가 부드럽게 이동하는 애니메이션 */
 @keyframes gradientMove {
   0% {
     background-position: 0% 50%;
@@ -153,7 +143,7 @@
   }
 }
 
-/* ?쇰쟻?대뒗 洹몃씪?곗씠??*/
+/* 계속 움직이는 그라디언트 배경 */
 .bg-wavy {
   background-image: linear-gradient(
     270deg,
@@ -167,7 +157,7 @@
   animation: gradientMove 20s ease-in-out infinite;
 }
 
-/* 媛?낆꽦???댁쭩 ?뚮윭二쇰뒗 ?ㅻ쾭?덉씠(?좏깮) */
+/* 가독성을 높이는 어두운 베일 오버레이(선택) */
 .bg-veil {
   background: radial-gradient(
       80% 60% at 50% 40%,
@@ -176,17 +166,14 @@
     ),
     rgba(0, 0, 0, 0.06);
 }
-/* .button {
-  background-color: #646cff;
-} */
-/* ?? 媛ㅻ윭由??ㅽ겕濡?媛???쒓굅 ??????????????????????????? */
+
+/* 갤러리 스크롤 영역: 스크롤바 공간을 고정해 레이아웃 흔들림 방지 */
 .galleryPane {
-  scrollbar-gutter: auto !important; /* ?꾩뿭 stable both-edges 臾대젰??*/
-  /* 蹂닿린 醫뗭? 湲곕낯 媛믩뱾 */
+  scrollbar-gutter: auto !important; /* 레이아웃 안정화(both-edges 유사 효과) */
   scrollbar-width: thin; /* Firefox */
 }
 
-/* WebKit (Chromium) ?ш린 ?듭씪 */
+/* WebKit(Chromium) 전용 커스텀 스크롤바 */
 .galleryPane::-webkit-scrollbar {
   width: 14px;
 }
@@ -198,22 +185,20 @@
   border-radius: 8px;
 }
 
-/* ?? Fallback: ?ъ쟾??媛?곌? ?⑤뒗 ?섍꼍 蹂댁젙 ?????????????
-   ?ㅽ겕濡ㅼ씠 ?ㅼ젣濡??앷릿 寃쎌슦?먮쭔(?먮컮?ㅽ겕由쏀듃濡?data-scroll-y 遺?? 
-   ?ㅻⅨ履?"?덉빟 怨듦컙"???뚯닔 留덉쭊?쇰줈 ?곸뇙?섍퀬 ?숈씪 ?ш린留뚰겮 ?대? ?⑤뵫??以섏꽌
-   肄섑뀗痢좉? ?섎━吏 ?딄쾶 ?⑸땲??  */
+/* Fallback: 스크롤바가 오버레이되는 환경에서 수동으로 오른쪽 여백 보정
+   (data-scroll-y="1"을 부여하면 패딩을 추가해 내용 흔들림을 방지) */
 .galleryPane[data-scroll-y="1"] {
-  --gutter-w: 14px; /* ?꾩쓽 ::-webkit-scrollbar width? 留욎땄 */
+  --gutter-w: 14px; /* ::-webkit-scrollbar 폭과 동일하게 유지 */
   margin-right: calc(-1 * var(--gutter-w));
   padding-right: var(--gutter-w);
 }
 
-/* Utility: NanumHuman font for editor */
+/* Utility: NanumHuman 폰트를 편집기에 적용 */
 .font-nanumhuman {
-  font-family: 'NanumHuman', ui-sans-serif, system-ui, sans-serif;
+  font-family: "NanumHuman", ui-sans-serif, system-ui, sans-serif;
 }
 
-/* Press effect for editor logo */
+/* 로고 프레스(눌림) 효과 */
 .logo-press {
   display: inline-flex;
   transform: scale(1);


### PR DESCRIPTION
# **Unity 모달 열 때 캔버스 선택 자동 해제하여 삭제 버튼 오버레이 문제 해결**

---

## 요약
- Unity 시뮬레이터 모달을 띄울 때, 캔버스에 선택된 객체가 있으면 삭제 버튼이 모달 위에 뜨는 문제를 수정했습니다.  
- 모달 표시 직전에 **현재 선택을 해제**하여(UI 버튼 제거) 시각적 충돌을 방지합니다.  

---

## 변경 사항
- **`frontend/src/contexts/UnityContext.jsx:17`**
  - `showUnity()`에서 `window.editorAPI.stageRef.current`에 접근  
  - 선택 객체가 존재하면 `discardActiveObject()`로 해제  
  - `requestRenderAll()`로 반영 후 모달 표시  

---

## 관련(참고)
- Unity 모달 오버레이: `frontend/src/App.jsx:118`  
- 삭제 버튼 렌더 위치 로직(선택 아이콘): `frontend/src/components/Canvas.jsx:1687`  

---

## 배경/문제
- 에디터에서 개체가 선택된 상태로 **“Unity 시뮬레이터 열기”** 실행 시,  
  캔버스 **삭제 버튼(쓰레기통 아이콘)** 이 높은 z-index로 모달 위에 나타남.  
- 사용자 시야를 가리고 잘못된 클릭을 유도할 수 있음.  

---

## 해결 방식
- Unity 모달을 띄우기 직전 **선택 상태 해제** → 삭제 버튼이 그려지지 않음.  
- `window.editorAPI.stageRef.current` 가 없거나 메서드가 없을 경우 대비:  
  - **안전 가드 처리** (`try/catch`, 타입 체크).  

---

## 테스트 방법
1. 에디터에서 아무 객체나 선택 → 삭제 버튼(쓰레기통 아이콘)이 표시되도록 함.  
2. 상단 Navbar 혹은 툴바에서 **“Unity 시뮬레이터 열기”** 클릭.  
3. 기대 결과:  
   - Unity 모달이 뜨기 전에 선택이 해제되어 삭제 버튼이 사라짐  
   - 모달 위로 어떠한 캔버스 UI도 겹치지 않음  
4. ESC로 모달 닫기 동작 확인  
5. 모달 닫은 후 캔버스 정상 상호작용(선택/이동/그리기) 확인  


---

## 대안 고려
- CSS로 모달 오버레이 `z-index` 를 더 높게 조정하는 방법도 있었으나,  
  이는 **근본 원인(선택 UI가 남아 있음)을 해결하지 못하므로 배제**.  


---

## 추가 개선 제안 (옵션)
- 모달 닫을 때 **이전 선택 상태 복원** 옵션 제공  
- 삭제 버튼 DOM `z-index` 를 모달보다 낮게(혹은 에디터 영역까지만) 제한하는 보조적 CSS 정리  
