### PR TITLE
fix: 씬 생성시 이전 씬 저장

### DIFF
--- a/frontend/src/pages/EditorPage.jsx
+++ b/frontend/src/pages/EditorPage.jsx
@@ -543,10 +543,15 @@ export default function EditorPage({projectId = DUMMY}) {
       };
       const nextScenes = [...scenes, createdNorm];
       setScenes(nextScenes);
-      if (createdId) setSelectedId(createdId);
+      if (createdId) {
+        await handleSelect(createdId);
+      } else {
+        // 만약의 경우를 대비해 폴백
+        setSelectedId(null);
+      }
 
       const nextTotal = nextScenes.length + 1;
-      if (nextTotal > VISIBLE) setStart(nextTotal - VISIBLE);
+      if (nextTotal > VISIBLE) setStart(nextTotal - VISIBLE)
 
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
씬 생성 시, handleSelect를 명시적으로 호출하지 않아서 썸네일 저장과 캔버스 저장이 안 되는 문제 해결