### PR TITLE
fix: 브러쉬모드 -> 클릭모드로 수정

### DIFF
--- a/frontend/src/components/Canvas.jsx
+++ b/frontend/src/components/Canvas.jsx
@@ -17,7 +17,7 @@ export default function Canvas({
   height = 500,
   imageUrl = "",
   stageRef: externalStageRef,
-  drawingMode: externalDrawingMode = "draw",
+  drawingMode: externalDrawingMode = "select",
   eraserSize: externalEraserSize = 20,
   drawingColor: externalDrawingColor = '#222222',
   activeLayerId: externalActiveLayerId,
@@ -140,7 +140,6 @@ export default function Canvas({
     canvas.clipPath = clipPath;
 
     // 그리기 모드 설정 (성능 최적화)
-    canvas.isDrawingMode = true;
     const brush = new fabric.PencilBrush(canvas);
     brush.width = 2; // 원래 크기로 복원
     brush.color = externalDrawingColor; // 외부에서 전달받은 색상 사용

--- a/frontend/src/pages/EditorPage.jsx
+++ b/frontend/src/pages/EditorPage.jsx
@@ -1,4 +1,4 @@
-﻿import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import EditorToolbar from "../components/EditorToolbar.jsx";
 import MainCanvasSection from "../components/MainCanvasSection.jsx";
 import SceneCarousel from "../components/SceneCarousel.jsx";
@@ -426,12 +426,11 @@ export default function EditorPage({projectId = DUMMY}) {
             const firstScene = list[0];
             const isFirstSceneTransformed = firstScene.s3_key && firstScene.s3_key.startsWith('processed');
             
-            if (isFirstSceneTransformed) {
-              handleModeChange('brush');
-            } else {
-              handleModeChange('draw');
-            }
-          }, 100);
+                            if (isFirstSceneTransformed) {
+                              handleModeChange('select');
+                            } else {
+                              handleModeChange('select');
+                            }          }, 100);
         }
       } catch (e) {
         console.error(e);
@@ -604,10 +603,10 @@ export default function EditorPage({projectId = DUMMY}) {
     
     if (nextSceneTransformed) {
       // 변환된 씬: 브러쉬 도구로 전환
-      handleModeChange('brush');
+      handleModeChange('select');
     } else {
       // 변환 전 씬: 펜 그리기 도구로 전환
-      handleModeChange('draw');
+      handleModeChange('select');
     }
     
     const items = [...scenes, {id: "__ADD__", isAdd: true}];
@@ -768,7 +767,7 @@ export default function EditorPage({projectId = DUMMY}) {
           // 변환 완료 후 브러쉬 모드로 자동 전환
           setTimeout(() => {
             console.log('변환 완료: 브러쉬 모드로 자동 전환');
-            handleModeChange('brush');
+            handleModeChange('select');
           }, 100);
 
           // 이미지 로드 완료 후 useAutoSave를 통해 즉시 저장


### PR DESCRIPTION

## ✨ 기능 추가: 기본 모드를 `select`로 설정하고 브러시 자동 활성화 방지

이 커밋은 다양한 상황에서 브러시 또는 드로잉 모드가 자동으로 활성화되어 캔버스에 의도치 않게 그림이 그려지는 문제를 해결합니다.

---

### 🔑 주요 변경 사항

#### **Canvas.jsx**

* 초기 캔버스 설정(`useLayoutEffect`)에서 하드코딩된 `canvas.isDrawingMode = true;`를 제거.
* `drawingMode` prop의 기본값을 `"select"`로 변경하여, 명시적으로 지정되지 않은 경우 기본적으로 선택 모드에서 시작하도록 수정.

#### **EditorPage.jsx**

* 프로젝트 최초 로드시 실행되는 `useEffect` 로직을 수정해 항상 `drawingMode`가 `"select"`로 설정되도록 변경.
* 새로운 씬이 선택될 때 `drawingMode`가 기본적으로 `"select"`로 돌아가도록 `handleSelect` 함수 업데이트.
* 변환 작업이 완료된 후 브러시 모드로 자동 전환되는 문제를 방지하기 위해, `handleTransform` 함수에서 `drawingMode`를 `"select"`로 설정하도록 수정.

---

### 📝 결론

이 변경으로 드로잉 도구는 사용자가 **명시적으로 활성화했을 때만** 실행되며, 불필요한 선이나 흔적이 생기지 않습니다. 결과적으로 더 직관적이고 안정적인 사용자 경험을 제공합니다.

---

