### PR TITLE
fix : setDrawingColor 버그 픽스

### DIFF
--- a/frontend/src/hooks/canvas/useCanvasExternalStageApi.js
+++ b/frontend/src/hooks/canvas/useCanvasExternalStageApi.js
@@ -93,7 +93,7 @@ export default function useCanvasExternalStageApi({
       };
 
       externalStageRef.current.setDrawingColor = (color) => {
-        setDrawingColor(color);
+        updateBrushColor(color);
         setDrawingMode((currentMode) => {
           if (currentMode !== "pixelErase") {
             updateBrushColor(color);


### PR DESCRIPTION
## 변경 사항
- Frontend
  - `useCanvasExternalStageApi.js`
    - `externalStageRef.current.setDrawingColor` 구현에서 `setDrawingColor` 직접 호출을 제거하고 `updateBrushColor(color)` 중심으로 동작하도록 수정
    - `setDrawingMode` 내부에서 현재 모드가 `"pixelErase"`가 아닐 때만 브러쉬 색상 업데이트

---

## 기능 요약
- 외부 StageRef를 통해 브러쉬 색상을 변경할 때 발생하던 `setDrawingColor` 참조 오류 해결
- 픽셀 지우개 모드에서는 색상 변경이 반영되지 않도록 안전하게 처리
