### PR TITLE
feat: 프로젝트 목록 페이지네이션 + 무한스크롤 구현 및 레이아웃 개선

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -165,6 +165,14 @@ class ProjectDetailDataResponse(SuccessResponse):
     project: ProjectDetailResponse
 
 
+class ProjectListDataResponse(BaseModel):
+    """프로젝트 목록 + 전체 개수 반환 모델"""
+
+    success: bool = True
+    projects: List[ProjectResponse]
+    total: int = 0
+
+
 # schemas.py에서 Scene 관련 스키마 수정
 class SceneCreate(BaseModel):
     scene_num: int

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -89,11 +89,11 @@ const showGlobalNav = location.pathname !== "/" && location.pathname !== "/login
   }
 
 return (
-  <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
+  <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
     {/* 메인에서는 전역 Navbar를 숨기고, 다른 페이지에서만 보이게 */}
     {showGlobalNav && <Navbar />}  
       
-      <div style={{ flex: '1 1 auto', overflowY: 'hidden', position: 'relative' }}>
+  <div style={{ flex: '1 1 auto', overflowY: 'auto', position: 'relative' }}>
         <Routes location={background || location}>
           <Route path="/" element={<MainPage />} />
           <Route path="/dashboard" element={<PrivateRoute> <DashboardPage /> </PrivateRoute> }/>

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import client from "../api/client.js";
 import { useNavigate } from "react-router-dom";
@@ -47,10 +47,13 @@ export default function DashboardPage() {
   const navigate = useNavigate();
 
   const [projects, setProjects] = useState([]);
-  const [loading, setLoading] = useState(true);
+  // don't auto-load on mount; wait for user scroll
+  const [loading, setLoading] = useState(false);
   const [pageLoading, setPageLoading] = useState(false);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(true);
+  const [userScrolled, setUserScrolled] = useState(false);
+  const sentinelRef = useRef(null);
   const [editingProject, setEditingProject] = useState(null);
   const [creating, setCreating] = useState(false);
   const [bannerUrl, setBannerUrl] = useState("/img/banner_01.png");
@@ -71,29 +74,17 @@ export default function DashboardPage() {
   }, []);
 
 
-  // initial load
+  // don't fetch automatically on mount — wait for the user to scroll
   useEffect(() => {
     if (!isAuthenticated) {
       setLoading(false);
-      return;
-    }
-
-    const loadFirst = async () => {
-      setLoading(true);
+      setProjects([]);
       setOffset(0);
-      try {
-  const res = await client.get("/projects", { params: { limit: PAGE_SIZE, offset: 0 } });
-        setProjects(res.data.projects || []);
-        setHasMore((res.data.total || 0) > (res.data.projects || []).length);
-        setOffset((res.data.projects || []).length);
-      } catch (err) {
-        console.error("Failed to fetch projects:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadFirst();
+      setHasMore(true);
+    } else {
+      // authenticated but we still wait for user's scroll to load data
+      setLoading(false);
+    }
   }, [isAuthenticated]);
 
   // load more when offset changes or on explicit request
@@ -111,6 +102,24 @@ export default function DashboardPage() {
       console.error("Failed to load more projects:", err);
     } finally {
       setPageLoading(false);
+    }
+  };
+
+  // initial load function (fetch first page) -- keep this so the dashboard shows projects on first render
+  const loadFirst = async () => {
+    // avoid clashing with pageLoading
+    if (pageLoading) return;
+    setLoading(true);
+    try {
+      const res = await client.get("/projects", { params: { limit: PAGE_SIZE, offset: 0 } });
+      const items = res.data.projects || [];
+      setProjects(items);
+      setHasMore((res.data.total || 0) > items.length);
+      setOffset(items.length);
+    } catch (err) {
+      console.error("Failed to fetch projects:", err);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -160,13 +169,14 @@ export default function DashboardPage() {
 
   // IntersectionObserver for infinite scroll
   useEffect(() => {
-    const sentinel = document.getElementById("projects-sentinel");
-    if (!sentinel) return;
+    const node = sentinelRef.current;
+    if (!node) return;
 
     const obs = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting && hasMore && !pageLoading) {
+          // only trigger loading after the user has scrolled
+          if (entry.isIntersecting && hasMore && !pageLoading && userScrolled) {
             loadMore();
           }
         });
@@ -174,9 +184,54 @@ export default function DashboardPage() {
       { root: null, rootMargin: "200px", threshold: 0.1 }
     );
 
-    obs.observe(sentinel);
+    obs.observe(node);
     return () => obs.disconnect();
-  }, [offset, hasMore, pageLoading]);
+  }, [userScrolled, hasMore, pageLoading]);
+
+  // If the page is too short to scroll (e.g. small/minimized window) and we haven't
+  // received a user scroll, auto-trigger loading so content fills the viewport.
+  useEffect(() => {
+    try {
+      if (userScrolled) return;
+      const doc = document.documentElement;
+      const canScroll = doc.scrollHeight > window.innerHeight;
+      if (!canScroll && hasMore && !pageLoading) {
+        // Allow intersection observer and other logic to run as if the user scrolled
+        setUserScrolled(true);
+        // Load next page to try to fill viewport
+        loadMore();
+      }
+    } catch (e) {
+      // ignore if DOM not available
+    }
+  }, [projects, userScrolled, hasMore, pageLoading]);
+
+  // ensure first page is loaded when the user is authenticated (so the dashboard is not empty)
+  useEffect(() => {
+    if (isAuthenticated && projects.length === 0) {
+      loadFirst();
+    }
+  }, [isAuthenticated]);
+
+  // listen for the user's first scroll action; after that, allow intersection to trigger loads
+  useEffect(() => {
+    const onFirstScroll = () => {
+      setUserScrolled(true);
+      window.removeEventListener("scroll", onFirstScroll);
+
+      // If the sentinel is already in view when the user scrolls, trigger a load
+      const sentinel = sentinelRef.current;
+      if (sentinel && hasMore && !pageLoading) {
+        const rect = sentinel.getBoundingClientRect();
+        if (rect.top <= window.innerHeight + 200) {
+          loadMore();
+        }
+      }
+    };
+
+    window.addEventListener("scroll", onFirstScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onFirstScroll);
+  }, [hasMore, pageLoading]);
 
   const handleCreateProject = () => {
     setCreating(true);
@@ -299,7 +354,7 @@ export default function DashboardPage() {
                 ))}
 
                 {/* sentinel for infinite scroll */}
-                <div id="projects-sentinel" style={{ height: 1 }} />
+                <div id="projects-sentinel" ref={sentinelRef} style={{ height: 1 }} />
               </div>
             ) : (
               <div className="empty-state">


### PR DESCRIPTION
## 변경 사항
- Backend
  - `project.py`
    - `get_projects_by_user_id_paginated` 추가: limit/offset 기반 조회 + total count 반환
  - `project.py (router)`
    - 기존 `list_projects` → 페이지네이션 적용
    - `ProjectListResponse` → `ProjectListDataResponse`로 변경
    - limit 값 검증 (최대 100까지)
  - `schemas.py`
    - `ProjectListDataResponse` 추가: `success`, `projects`, `total` 포함

- Frontend
  - `App.jsx`
    - 레이아웃 수정: `height: 100vh` → `minHeight: 100vh`, 내부 스크롤 구조 개선
  - `DashboardPage.jsx`
    - 무한스크롤(Infinite Scroll) 기능 추가 (`IntersectionObserver` + sentinel)
    - 페이지네이션 API 연동 (`limit`, `offset` 기반)
    - 뷰포트가 작은 경우 자동으로 다음 페이지 로드되도록 처리
    - 로딩/더 불러오기/마지막 페이지 도달 메시지 표시

---

## 기능 요약
- 프로젝트 목록 API가 페이지네이션을 지원하도록 수정
- 대시보드에서 무한 스크롤로 프로젝트 목록 로딩 가능
- 작은 창(뷰포트) 환경에서도 정상적으로 프로젝트가 채워지도록 보완
- 로딩 중/마지막 페이지 표시로 UX 개선