### PR TITLE
feat: 드론 횟수 표시 및 씬별 카운트 실시간 반영

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useParams } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext.jsx";
 import { useUnity } from "../contexts/UnityContext.jsx";
 import client from "../api/client";
+import { getAllCanvasStates } from "../utils/indexedDBUtils";
 
 export default function Navbar({ transparent: propTransparent = false }) {
   const location = useLocation();
@@ -22,6 +23,12 @@ export default function Navbar({ transparent: propTransparent = false }) {
       selectedId: api?.selectedId || null,
       projectName: api?.projectName || "",
     }));
+
+    // IndexedDB에 저장된 objectCount 합계 (현재 프로젝트의 씬만)
+    const [savedObjectCount, setSavedObjectCount] = React.useState(0);
+    // 씬 목록(이름 포함)과 씬별 카운트 맵
+    const [projectScenes, setProjectScenes] = React.useState([]); // [{id, name, ...}]
+    const [perSceneCounts, setPerSceneCounts] = React.useState({}); // { [sceneId]: count }
 
     const sceneId = editorState.selectedId;
 
@@ -43,7 +50,7 @@ export default function Navbar({ transparent: propTransparent = false }) {
       const handler = (e) => {
         const { jsonUrl } = e.detail || {};
         if (jsonUrl) {
-          console.log('JSON URL received from editor:', jsonUrl);
+          console.log("JSON URL received from editor:", jsonUrl);
           setLastJsonUrl(jsonUrl);
           setJsonBuilt(true);
         }
@@ -51,6 +58,97 @@ export default function Navbar({ transparent: propTransparent = false }) {
       window.addEventListener("editor:json-ready", handler);
       return () => window.removeEventListener("editor:json-ready", handler);
     }, []);
+
+    // 현재 프로젝트에 속한 씬 목록을 서버에서 불러옴
+    React.useEffect(() => {
+      const loadProjectScenes = async () => {
+        try {
+          if (!projectId) {
+            setProjectScenes([]);
+            return;
+          }
+          const res = await client.get(`/projects/${projectId}/scenes`);
+          const list = res.data?.scenes || [];
+          // normalize scene objects (id and name)
+          const scenes = list.map((s) => ({
+            id: s.id,
+            name: s.name || `Scene ${s.scene_num || ""}`,
+          }));
+          setProjectScenes(scenes);
+        } catch (e) {
+          console.warn("Failed to load project scenes for Navbar:", e);
+          setProjectScenes([]);
+        }
+      };
+
+      loadProjectScenes();
+    }, [projectId]);
+
+    // IndexedDB에 저장된 씬들 중 현재 프로젝트의 씬만 objectCount 합산
+    const refreshSavedObjectCount = React.useCallback(async () => {
+      try {
+        const states = await getAllCanvasStates();
+        // build per-scene map only for scenes in current project
+        const ids = new Set(projectScenes.map((s) => s.id));
+        const map = {};
+        let total = 0;
+        states.forEach((s) => {
+          if (ids.has(s.sceneId)) {
+            const c = s.objectCount || 0;
+            map[s.sceneId] = c;
+            total += c;
+          }
+        });
+        // Ensure scenes with no saved state show 0
+        projectScenes.forEach((sc) => {
+          if (!map[sc.id]) map[sc.id] = 0;
+        });
+        setPerSceneCounts(map);
+        setSavedObjectCount(total);
+      } catch (err) {
+        console.warn("Failed to refresh saved object count:", err);
+      }
+    }, [projectScenes]);
+
+    // 실시간 반영: indexeddb 저장 이벤트 및 에디터 이벤트에 반응
+    React.useEffect(() => {
+      // 초기 로드
+      refreshSavedObjectCount();
+
+      const onIndexedDbSave = (e) => {
+        const d = e.detail || {};
+        // 프로젝트에 속한 씬에 대한 저장이면 갱신
+        if (d && d.sceneId && projectScenes.find((p) => p.id === d.sceneId)) {
+          refreshSavedObjectCount();
+        }
+      };
+
+      const onIndexedDbDelete = (e) => {
+        const d = e.detail || {};
+        if (d && d.sceneId && projectScenes.find((p) => p.id === d.sceneId)) {
+          // 삭제된 씬의 카운트는 0으로 처리
+          refreshSavedObjectCount();
+        }
+      };
+
+      const onEditorUpdated = () => refreshSavedObjectCount();
+      const onJsonReady = () => refreshSavedObjectCount();
+
+      window.addEventListener("indexeddb:canvas-saved", onIndexedDbSave);
+      window.addEventListener("indexeddb:canvas-deleted", onIndexedDbDelete);
+      window.addEventListener("editor:updated", onEditorUpdated);
+      window.addEventListener("editor:json-ready", onJsonReady);
+
+      return () => {
+        window.removeEventListener("indexeddb:canvas-saved", onIndexedDbSave);
+        window.removeEventListener(
+          "indexeddb:canvas-deleted",
+          onIndexedDbDelete
+        );
+        window.removeEventListener("editor:updated", onEditorUpdated);
+        window.removeEventListener("editor:json-ready", onJsonReady);
+      };
+    }, [refreshSavedObjectCount]);
 
     const [localDots, setLocalDots] = React.useState(
       () => Number(api?.targetDots) || 2000
@@ -71,13 +169,16 @@ export default function Navbar({ transparent: propTransparent = false }) {
       api.setTargetDots(safe);
     };
 
-
     return (
       <nav className="px-4 py-2 mb-4 flex justify-center font-nanumhuman">
         <div className="w-full flex justify-between items-center gap-40">
           {/* Logo + Project name */}
           <div className="flex items-center gap-3">
-            <Link to="/" title="메인 페이지" className="logo-press flex items-center">
+            <Link
+              to="/"
+              title="메인 페이지"
+              className="logo-press flex items-center"
+            >
               <img src="/img/Logo.png" alt="Logo" className="h-10 w-auto" />
             </Link>
             <div
@@ -85,6 +186,36 @@ export default function Navbar({ transparent: propTransparent = false }) {
               title={editorState.projectName || "Untitled Project"}
             >
               {editorState.projectName || "Untitled Project"}
+              <span
+                className="ml-3 inline-flex items-center gap-2 text-sm font-medium text-gray-800"
+                title={(() => {
+                  // 툴팁: 각 씬별 카운트 나열
+                  try {
+                    const lines = projectScenes.map((sc) => {
+                      const c = perSceneCounts?.[sc.id] ?? 0;
+                      return `${sc.name || sc.id}: ${c}`;
+                    });
+                    if (lines.length === 0) return `Total: ${savedObjectCount}`;
+                    return (
+                      `Selected scene: ${
+                        sceneId || "-"
+                      }\nTotal: ${savedObjectCount}\n` + lines.join("\n")
+                    );
+                  } catch (_) {
+                    return `Total: ${savedObjectCount}`;
+                  }
+                })()}
+              >
+                <span className="text-base font-medium">드론 횟수 :</span>
+                <span className="text-base">
+                  {(() => {
+                    try {
+                      if (sceneId) return perSceneCounts?.[sceneId] ?? 0;
+                    } catch (_) {}
+                    return savedObjectCount;
+                  })()}
+                </span>
+              </span>
             </div>
           </div>
 

--- a/frontend/src/utils/indexedDBUtils.js
+++ b/frontend/src/utils/indexedDBUtils.js
@@ -154,6 +154,22 @@ export const saveCanvasToIndexedDB = async (sceneId, canvasData, metadata = {}) 
         // 메모리 캐시도 업데이트
         setMemoryCache(sceneId, canvasData);
 
+        // UI 등에서 실시간 변화를 감지할 수 있도록 이벤트 발행
+        try {
+          if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            const ev = new CustomEvent('indexeddb:canvas-saved', {
+              detail: {
+                sceneId,
+                objectCount: canvasState.objectCount || 0,
+                savedAt: canvasState.savedAt
+              }
+            });
+            window.dispatchEvent(ev);
+          }
+        } catch (e) {
+          console.warn('Failed to dispatch indexeddb:canvas-saved event', e);
+        }
+
         resolve(canvasState);
       };
 
@@ -245,6 +261,17 @@ export const deleteCanvasFromIndexedDB = async (sceneId) => {
 
       request.onsuccess = () => {
         console.log(`Canvas state deleted from IndexedDB: ${sceneId}`);
+        // 삭제 이벤트 발행
+        try {
+          if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            const ev = new CustomEvent('indexeddb:canvas-deleted', {
+              detail: { sceneId }
+            });
+            window.dispatchEvent(ev);
+          }
+        } catch (e) {
+          console.warn('Failed to dispatch indexeddb:canvas-deleted event', e);
+        }
         resolve(true);
       };
 


### PR DESCRIPTION
## 변경 사항
- Frontend
  - **Navbar.jsx**
    - 프로젝트 씬 목록 불러오기 로직 추가 (`/projects/{projectId}/scenes` 호출).
    - IndexedDB 기반으로 씬별 `objectCount` 집계 및 총합 표시 기능 구현.
    - 씬 저장/삭제/에디터 이벤트 발생 시 드론 횟수 자동 갱신.
    - 프로젝트명 옆에 툴팁으로 씬별 드론 수와 총합 확인 가능.
    - UI에 현재 선택된 씬 혹은 전체 드론 횟수 표시.
  - **indexedDBUtils.js**
    - `saveCanvasToIndexedDB` 실행 시 `indexeddb:canvas-saved` 이벤트 발행.
    - `deleteCanvasFromIndexedDB` 실행 시 `indexeddb:canvas-deleted` 이벤트 발행.
    - 이벤트에는 `sceneId`, `objectCount`, `savedAt` 등의 데이터 포함.

---

## 기능 요약
- Navbar에서 **현재 씬 또는 전체 프로젝트의 드론 횟수**를 실시간으로 확인 가능.
- 씬 저장/삭제/편집 시 드론 수가 자동 갱신.
- 프로젝트명 hover 시 씬별 드론 카운트 목록 툴팁 제공.