### PR TITLE
chore : 에디터 페이지 스크롤 고정, 왼쪽 aside바 정상처리

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,8 @@ function AppContent() {
   const navigate = useNavigate();
   const { isUnityVisible, showUnity, hideUnity } = useUnity();
   const { isAuthenticated, logout, loading } = useAuth();
-const showGlobalNav = location.pathname !== "/" && location.pathname !== "/login";
+  const showGlobalNav = location.pathname !== "/" && location.pathname !== "/login";
+  const isEditorRoute = location.pathname.startsWith("/projects/");
   useEffect(() => {
     const handleEscape = (event) => {
       if (event.key === "Escape" && isUnityVisible) {
@@ -94,7 +95,7 @@ return (
     {/* 메인에서는 전역 Navbar를 숨기고, 다른 페이지에서만 보이게 */}
     {showGlobalNav && <Navbar />}  
       
-  <div style={{ flex: '1 1 auto', overflowY: 'auto', position: 'relative' }}>
+  <div style={{ flex: '1 1 auto', position: 'relative', display: 'flex', flexDirection: 'column', overflowX: 'hidden', overflowY: isEditorRoute ? 'hidden' : 'auto' }}>
         <Routes location={background || location}>
           <Route path="/" element={<MainPage />} />
           <Route path="/dashboard" element={<PrivateRoute> <DashboardPage /> </PrivateRoute> }/>

--- a/frontend/src/styles/EditorPage.css
+++ b/frontend/src/styles/EditorPage.css
@@ -6,8 +6,9 @@
 
 .editor-shell {
   width: 100%;
-  height: auto;
+  height: calc(100dvh - var(--app-header-h));
   min-height: calc(100dvh - var(--app-header-h));
+  flex: 1 1 auto;
   background: #fff;
   display: flex;
   align-items: stretch;
@@ -41,8 +42,6 @@
   box-sizing: border-box;
   z-index: 1200;
 
-  /* ✅ sticky가 ‘얼마나 길지’ 알아야 하므로 높이 명시 */
-  height: 100dvh; /* 헤더가 있으면 calc(100dvh - var(--app-header-h)) */
   display: flex; /* 내부를 flex column으로 채우기 위해 */
 }
 
@@ -110,6 +109,7 @@
 
 .main-content {
   flex: 1 1 auto;
+  display: flex;
   flex-direction: column;
   min-height: 0;
   max-height: calc(100dvh - var(--app-header-h)); /* ✅ 한 화면에 고정 */
@@ -140,7 +140,6 @@
   z-index: 50;
 
   /* ✅ 전고정 높이 */
-  height: 100dvh; /* 헤더 있으면 calc(100dvh - var(--app-header-h)) */
   display: flex;
 }
 .right-panel-inner {


### PR DESCRIPTION
## 변경 사항
- Backend
  - 없음
- Frontend
  - **App.jsx**
    - `isEditorRoute` 조건 추가하여 에디터 페이지(`/projects/`)에서는 스크롤 비활성화.
    - 메인 컨테이너에 `flex`, `flexDirection: 'column'`, `overflowX: 'hidden'`, `overflowY: isEditorRoute ? 'hidden' : 'auto'` 적용.
  - **EditorPage.css**
    - `.editor-shell`: `height: calc(100dvh - var(--app-header-h))` → `min-height`로 수정.
    - 불필요한 `height: 100dvh` 제거하여 aside 바 높이 처리 정상화.
    - `.main-content`: `flex-direction: column`, `min-height: 0` 추가 및 고정 높이 보정.

---

## 기능 요약
- 에디터 페이지에서 **세로 스크롤이 고정**되어 더 이상 화면이 흔들리지 않음.
- 왼쪽 aside 바가 **정상적인 높이와 레이아웃**을 유지하도록 수정됨.
- 전체 레이아웃이 뷰포트에 맞게 안정적으로 동작.