### PR TITLE
fix : 프로젝트 설정 모달에서 format 제거

### DIFF
--- a/frontend/src/components/ProjectSettingsModal.jsx
+++ b/frontend/src/components/ProjectSettingsModal.jsx
@@ -7,7 +7,6 @@ export default function ProjectSettingsModal({ project, onClose, onSaved, mode: 
 
   const [form, setForm] = useState({
     project_name: "",
-    format: "dsj",
     max_scene: 15,
     max_drone: 1000,
     max_speed: 6.0,
@@ -21,7 +20,6 @@ export default function ProjectSettingsModal({ project, onClose, onSaved, mode: 
     if (project) {
       setForm({
         project_name: project.project_name ?? "",
-        format: project.format ?? "dsj",
         max_scene: project.max_scene ?? 15,
         max_drone: project.max_drone ?? 1000,
         max_speed: project.max_speed ?? 6.0,
@@ -31,7 +29,6 @@ export default function ProjectSettingsModal({ project, onClose, onSaved, mode: 
     } else {
       setForm({
         project_name: "",
-        format: "dsj",
         max_scene: 15,
         max_drone: 1000,
         max_speed: 6.0,
@@ -45,7 +42,7 @@ export default function ProjectSettingsModal({ project, onClose, onSaved, mode: 
     const val = e.target.value;
     setForm((prev) => ({
       ...prev,
-      [key]: key === "project_name" || key === "format" ? val : val === "" ? "" : Number(val),
+      [key]: key === "project_name" ? val : val === "" ? "" : Number(val),
     }));
   };
 
@@ -68,7 +65,6 @@ export default function ProjectSettingsModal({ project, onClose, onSaved, mode: 
 
     const payload = {
       project_name: form.project_name,
-      format: form.format || "dsj",
       max_scene: Number(form.max_scene),
       max_drone: Number(form.max_drone),
       max_speed: Number(form.max_speed),
@@ -144,17 +140,6 @@ export default function ProjectSettingsModal({ project, onClose, onSaved, mode: 
             />
           </div>
 
-          <div>
-            <label className="block text-sm font-medium mb-1">format</label>
-            <input
-              type="text"
-              value={form.format}
-              onChange={updateField("format")}
-              className="w-full rounded border border-gray-300 px-3 py-2"
-              placeholder="dsj"
-            />
-            <p className="mt-1 text-xs text-gray-500">기본 format은 'dsj' 입니다</p>
-          </div>
 
           <div className="grid grid-cols-2 gap-3">
             <label className="block">

--- a/frontend/src/styles/CanvasTools.css
+++ b/frontend/src/styles/CanvasTools.css
@@ -203,7 +203,7 @@
   font-size: 12px;
   white-space: nowrap;
   /* Keep above any app overlays; OS scrollbars may still overlay */
-  z-index: 2147483647; /* max-ish */
+  z-index: 1000; /* max-ish */
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   pointer-events: none;
 }
@@ -224,7 +224,7 @@
   border-radius: 6px;
   font-size: 12px;
   white-space: nowrap;
-  z-index: 2147483647;
+  z-index: 1000;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   pointer-events: none;
 }


### PR DESCRIPTION
## 변경 사항
- Frontend
  - `ProjectSettingsModal.jsx`
    - `form` 상태에서 `format` 필드를 제거
    - 초기화 및 업데이트 로직에서 `format` 관련 코드 삭제
    - `payload` 전송 시 `format` 제거
    - UI 입력 필드(`format` 입력창 및 라벨) 삭제
  - `CanvasTools.css`
    - 불필요하게 과도했던 `z-index: 2147483647` 값을 `1000`으로 조정

---

## 기능 요약
- 프로젝트 설정 모달에서 `format` 입력 필드를 제거하여 UI 단순화
- CSS z-index 값 조정을 통해 레이어 관리 개선 및 다른 요소와의 충돌 방지
