### PR TITLE
fix: 브라우저 줌/화면비 변경 시 Fabric.js 캔버스 픽셀 불일치 수정 및 뷰포트 처리 개선

### DIFF
--- a/frontend/src/hooks/canvas/useCanvasInit.js
+++ b/frontend/src/hooks/canvas/useCanvasInit.js
@@ -58,7 +58,10 @@ export default function useCanvasInit({
       selection: false,
       skipTargetFind: false,
       perPixelTargetFind: false,
-      enableRetinaScaling: false,
+      // enable retina scaling so fabric keeps backing store in sync with
+      // devicePixelRatio / browser zoom. This helps avoid blurry or
+      // mis-positioned content when the user changes browser zoom.
+      enableRetinaScaling: true,
     });
 
     const clipPath = new fabric.Rect({
@@ -89,6 +92,20 @@ export default function useCanvasInit({
       }
     } catch (_) {}
     fabricCanvasRef.current = canvas;
+
+    // Ensure the canvas DOM element has explicit CSS width/height that
+    // matches the logical size. Fabric will manage the internal backing
+    // store size (retina) when `enableRetinaScaling` is enabled, but
+    // setting these styles avoids mismatch between CSS pixels and
+    // canvas internal pixels when the browser zoom/devicePixelRatio
+    // changes.
+    try {
+      const el = canvas.getElement();
+      if (el) {
+        el.style.width = `${width}px`;
+        el.style.height = `${height}px`;
+      }
+    } catch (_) {}
 
     if (externalStageRef) {
       externalStageRef.current = canvas;

--- a/frontend/src/hooks/canvas/useCanvasViewport.js
+++ b/frontend/src/hooks/canvas/useCanvasViewport.js
@@ -8,12 +8,29 @@ export default function useCanvasViewport(fabricCanvasRef, width, height) {
     if (!canvas) return;
 
     const base = baseSizeRef.current || { w: width, h: height };
+    // Update logical canvas size
     canvas.setWidth(width);
     canvas.setHeight(height);
 
-    const zx = width / (base.w || 1);
-    const zy = height / (base.h || 1);
-    const z = Math.min(zx, zy);
+    // Also update the DOM element CSS size so layout and overlay
+    // calculations (like delete button positioning) use consistent
+    // clientWidth/clientHeight values even when devicePixelRatio changes.
+    try {
+      const el = canvas.getElement();
+      if (el) {
+        el.style.width = `${width}px`;
+        el.style.height = `${height}px`;
+      }
+    } catch (_) {}
+
+  const zx = width / (base.w || 1);
+  const zy = height / (base.h || 1);
+  let z = Math.min(zx, zy);
+
+  // If retina scaling is enabled, Fabric will scale the backing store
+  // to account for window.devicePixelRatio. We still use viewport zoom
+  // for logical zooming; don't multiply by devicePixelRatio here, but
+  // keep element CSS sizes consistent.
     canvas.setZoom(z);
 
     const vpt = canvas.viewportTransform || [z, 0, 0, z, 0, 0];


### PR DESCRIPTION
## 변경 사항  
- Frontend  
  - **useCanvasInit.js**  
    - `enableRetinaScaling`을 `true`로 변경하여 브라우저 줌 및 devicePixelRatio 변경 시 캔버스 내부 backing store가 CSS 픽셀과 일치하도록 수정  
    - 캔버스 DOM element에 명시적으로 `style.width` / `style.height`를 설정하여 CSS 크기와 논리적 크기 일치 보장  

  - **useCanvasViewport.js**  
    - 캔버스 `setWidth` / `setHeight` 후 DOM element의 CSS 크기를 동기화하도록 추가 처리  
    - devicePixelRatio 변경 시에도 CSS 픽셀 기준의 레이아웃 계산(예: 삭제 버튼 위치)이 올바르게 작동되도록 개선  
    - retina scaling 활성화 시 devicePixelRatio를 viewport zoom에 곱하지 않고, Fabric.js 내부에서만 관리되도록 정리  

---

## 기능 요약  
- 브라우저 줌인/줌아웃 시 캔버스 콘텐츠가 흐려지거나 좌표가 어긋나는 문제 해결  
- CSS 픽셀과 내부 캔버스 픽셀 불일치로 인한 UI 오작동 방지  
- 삭제 버튼 등 오버레이 UI의 위치 계산이 안정적으로 동작  
