### PR TITLE
feat: JSON 내 scene 개수 및 max_scene 동기화 오류 수정

### DIFF
--- a/backend/app/routers/project.py
+++ b/backend/app/routers/project.py
@@ -248,8 +248,8 @@ async def export_project_to_json(
         "format": (project["format"] or "dsj").strip(),
         "show": {
             "show_name": project["project_name"] or "Untitled Show",
-            "max_drone": int(project["max_drone"] or 1),  # DB의 max_scene 값 사용
-            "max_scene": int(project["max_scene"] or 1),
+            "max_drone": int(project["max_drone"] or 1),
+            "max_scene": len(scenes),
         },
         "constraints": {
             "max_speed": float(project["max_speed"] or 6.0),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -76,7 +76,6 @@ class ProjectBase(BaseModel):
         ..., description="프로젝트 이름", example="새 드론쇼 프로젝트"
     )
     format: str = Field("dsj", description="프로젝트 포맷", example="dsj")
-    max_scene: int = Field(..., description="최대 씬 개수", example=15)
     max_drone: int = Field(..., description="최대 드론 개수", example=10)
     max_speed: float = Field(..., description="최대 속도", example=6.0)
     max_accel: float = Field(..., description="최대 가속도", example=3.0)
@@ -94,9 +93,6 @@ class ProjectUpdate(BaseModel):
 
     project_name: Optional[str] = Field(
         None, description="수정할 프로젝트 이름", example="수정된 프로젝트 이름"
-    )
-    max_scene: Optional[int] = Field(
-        None, description="수정할 최대 씬 개수", example=20
     )
     max_drone: Optional[int] = Field(
         None, description="수정할 최대 드론 개수", example=15
@@ -175,7 +171,7 @@ class ProjectListDataResponse(BaseModel):
 
 # schemas.py에서 Scene 관련 스키마 수정
 class SceneCreate(BaseModel):
-    scene_num: int
+    scene_num: Optional[int] = None
 
 
 class SceneUpdate(BaseModel):

--- a/frontend/src/components/ProjectSettingsModal.jsx
+++ b/frontend/src/components/ProjectSettingsModal.jsx
@@ -12,7 +12,6 @@ export default function ProjectSettingsModal({
 
   const [form, setForm] = useState({
     project_name: "",
-    max_scene: 15,
     max_drone: 1000,
     max_speed: 6.0,
     max_accel: 3.0,
@@ -28,7 +27,6 @@ export default function ProjectSettingsModal({
     if (project) {
       setForm({
         project_name: project.project_name ?? "",
-        max_scene: project.max_scene ?? 15,
         max_drone: project.max_drone ?? 1000,
         max_speed: project.max_speed ?? 6.0,
         max_accel: project.max_accel ?? 3.0,
@@ -37,7 +35,6 @@ export default function ProjectSettingsModal({
     } else {
       setForm({
         project_name: "",
-        max_scene: 15,
         max_drone: 1000,
         max_speed: 6.0,
         max_accel: 3.0,
@@ -64,7 +61,6 @@ export default function ProjectSettingsModal({
     }
 
     const numericKeys = [
-      "max_scene",
       "max_drone",
       "max_speed",
       "max_accel",
@@ -79,7 +75,6 @@ export default function ProjectSettingsModal({
 
     const payload = {
       project_name: form.project_name,
-      max_scene: Number(form.max_scene),
       max_drone: Number(form.max_drone),
       max_speed: Number(form.max_speed),
       max_accel: Number(form.max_accel),
@@ -152,29 +147,25 @@ export default function ProjectSettingsModal({
           <div>
             <label className="block text-sm font-medium mb-1">
               프로젝트 이름
-            </label>
-            <input
-              type="text"
-              value={form.project_name}
-              onChange={updateField("project_name")}
-              className="w-full rounded border border-gray-300 px-3 py-2"
-              placeholder="프로젝트 이름"
-              required
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <label className="block">
-              <div className="text-sm font-medium mb-1">max_scene</div>
               <input
-                type="number"
-                inputMode="numeric"
-                value={form.max_scene}
-                onChange={updateField("max_scene")}
+                type="text"
+                value={form.project_name}
+                onChange={updateField("project_name")}
                 className="w-full rounded border border-gray-300 px-3 py-2"
-                min={0}
+                placeholder="프로젝트 이름"
+                required
               />
             </label>
+          </div>
+
+          {Number.isFinite(project?.max_scene) && (
+            <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+              현재 씬 수는 에디터에서 자동으로 {project.max_scene}개로
+              관리됩니다.
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
             <label className="block">
               <div className="text-sm font-medium mb-1">max_drone</div>
               <input


### PR DESCRIPTION
## 변경 사항
- Backend
  - `project.py`
    - `create_project` 시 `max_scene`을 항상 0으로 초기화하도록 수정.
    - `get_project_by_id`에서 `project_scenes`와 JOIN 후 씬 개수를 계산하여 `max_scene` 필드를 DB와 동기화.
    - `update_project_by_id`에서 `max_scene` 필드 수정을 무시하도록 변경.
  - `project.py/delete_project_by_id`에서 고아(scene) 정리 로직 유지.
  - `routers/project.py/export_project_to_json`에서 `max_scene`을 DB 값 대신 `len(scenes)`로 반영.
  - `schemas.py`
    - `ProjectBase`에서 `max_scene` 필드 제거.
    - `SceneCreate`의 `scene_num`을 optional로 변경.
- Frontend
  - `ProjectSettingsModal.jsx`
    - 프로젝트 설정에서 `max_scene` 입력 제거.
  - `EditorPage.jsx`
    - `useEffect`로 `scenes.length`를 기반으로 `projectMeta.max_scene` 갱신.
    - `handleAddScene`에서 서버 응답 기반으로 씬 번호/개수 반영 로직 수정.

---

## 기능 요약
- 프로젝트 생성 시 `max_scene`은 자동 계산되며, 더 이상 사용자가 직접 입력/수정하지 않음.
- JSON export 시 씬 개수가 항상 실제 씬 개수와 일치하도록 보장.
- 프론트엔드에서도 씬 추가 시 projectMeta와 동기화되어 UI와 백엔드 데이터가 일관되게 유지됨.