### PR TITLE
fix: max_drone 수치 fix

### DIFF
--- a/backend/app/routers/project.py
+++ b/backend/app/routers/project.py
@@ -206,7 +206,9 @@ async def export_project_to_json(
         raise HTTPException(status_code=404, detail="No scenes found")
 
     all_scenes_data = []
-    max_drone = int(project["max_drone"]);
+    project_max_drone_raw = project["max_drone"]
+    project_max_drone = int(project_max_drone_raw) if project_max_drone_raw is not None else None
+    max_drones_in_scenes = 0
 
     for i, scene in enumerate(scenes):
         scene_id = scene["id"]
@@ -229,8 +231,8 @@ async def export_project_to_json(
                 scene_w, scene_h, scene_z = get_fabric_json_size(processed_path)
 
                 # 드론 수 갱신
-                max_drone = min(len(coords_with_colors), max_drone)
-                print(len(coords_with_colors))
+                drone_count = len(coords_with_colors)
+                max_drones_in_scenes = max(max_drones_in_scenes, drone_count)
 
                 # 개별 씬 액션 데이터 생성
                 actions = []
@@ -268,7 +270,7 @@ async def export_project_to_json(
         "format": (project["format"] or "dsj").strip(),
         "show": {
             "show_name": project["project_name"] or "Untitled Show",
-            "max_drone": max_drone,
+            "max_drone": project_max_drone if project_max_drone is not None else max_drones_in_scenes,
             "max_scene": len(scenes),
         },
         "constraints": {


### PR DESCRIPTION
## 변경 사항
- Backend
  - `backend/app/routers/project.py`
    - `max_drone` 계산 로직 수정
      - `project["max_drone"]` 값이 `None`일 경우 안전하게 처리하도록 `project_max_drone` 변수를 추가
      - 씬별 드론 개수를 추적(`max_drones_in_scenes`)하여 프로젝트 전체 `max_drone` 값 산출
      - 최종 JSON export 시 `project_max_drone`이 있으면 그대로 사용, 없으면 씬별 최대 드론 수 사용

---

## 기능 요약
- `export_project_to_json` 시 `max_drone` 값이 잘못 줄어드는 문제 해결
- 프로젝트 생성 시 설정된 `max_drone`을 우선적으로 반영
- 프로젝트에 별도 설정이 없을 경우 씬 내 최대 드론 수를 반영